### PR TITLE
修复calls函数中调用$off引起calls列表报错的bug

### DIFF
--- a/src/helper/event.js
+++ b/src/helper/event.js
@@ -40,7 +40,11 @@ var API = {
       fn = fn.real || fn;
       for (var i = 0, len = calls.length; i < len; i++) {
         if (fn === calls[i]) {
-          calls.splice(i, 1);
+          setTimeout((function (n){
+            return function () {
+              calls.splice(n, 1);
+            }
+			    })(i),0);
           return context;
         }
       }


### PR DESCRIPTION
如下调用会引发bug
this.$once("test",function () {
      console.log(0);
});
this.$once("test",function () {
      console.log(0);
});
this.$emit("test");

主要是还在calls调用阶段就移除了calls队列里的调用函数，这里通过setTimeout把函数移除放到队列调用之后