### PR TITLE
fixed #166

### DIFF
--- a/lib/helper/extend.js
+++ b/lib/helper/extend.js
@@ -38,7 +38,7 @@ function wrap( k, fn, supro ) {
 function process( what, o, supro ) {
   for ( var k in o ) {
     if (o.hasOwnProperty(k)) {
-      if(hooks[k]) {
+      if(hooks.hasOwnProperty(k)) {
         hooks[k](o[k], what, supro)
       }
       what[k] = isFn( o[k] ) && isFn( supro[k] ) && 

--- a/test/spec/browser-bugfix.js
+++ b/test/spec/browser-bugfix.js
@@ -461,7 +461,15 @@ var template = '<input type="text"  class="form-control" \
     outer.destroy();
 
   })
+  it('bugfix #166',function () {
+      expect(function(){
+          var component = Regular.extend({
+              watch:function () {
 
+              }
+          })
+      }).to.not.throwException();
+  })
 
 })
 


### PR DESCRIPTION
fixed #166 将单纯的有无判断变为对属性的判断，防止prototype的干扰。如果是extend类似toString的属性虽然表现没问题不会报错但是实际会调用到Object的toString方法，潜在风险。