### PR TITLE
add unpkg and jsdelivr field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "main": "lib/index.js",
   "unpkg": "dist/regular.js",
+  "jsdelivr": "dist/regular.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/regularjs/regular"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "data-binding"
   ],
   "main": "lib/index.js",
+  "unpkg": "dist/regular.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/regularjs/regular"


### PR DESCRIPTION
[unpkg](https://unpkg.com) 提供了一个新的字段 `unpkg`，用来指定访问 `https://unpkg.com/<package-name>` 时重定向到哪个文件

具体一点地说，现在访问 https://unpkg.com/regularjs， 返回的是 commonjs 的代码，比较合理的应该是返回 `dist/regular.js`

unpkg: https://unpkg.com/regularjs
jsdelivr: https://cdn.jsdelivr.net/npm/regularjs

相关链接：
[RFC: Remove support for `browser` field and ?main at "bare" URLs](https://github.com/unpkg/unpkg-website/issues/63)
[jsDelivr Features](https://www.jsdelivr.com/features)