### PR TITLE
feat(build):  bundling with rollup, use headless chrome for ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ branches:
   - master
   - next
 before_install:
-- npm install -g casperjs phantomjs gulp
+- npm install -g puppeteer gulp

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,6 +20,9 @@ const nodeResolve = require('rollup-plugin-node-resolve');
 const rollup = require('rollup-stream');
 const source = require('vinyl-source-stream');
 const buffer = require('vinyl-buffer');
+const replace = require('rollup-plugin-replace')
+const argv = require('yargs').argv;
+const isProduction = (argv.production === undefined) ? false : true;
 var pkg;
 
 function inc(importance) {
@@ -137,18 +140,20 @@ gulp.task('build',["jshint"], function(){
           jsnext: true,
           main: true
         }),
-        commonjs()
+        commonjs(),
+        replace({
+          'process.env.NODE_ENV': isProduction ? "production":"developement"
+        })
      ]
     })
-     // give the file the name you want to output with
-    .pipe(source('index.js', "./lib"))
+    .pipe(source('regular.js', "./lib"))
     .pipe(buffer())
     .pipe(wrap(signatrue))
     .pipe(gulp.dest('./dist'))
     .pipe(wrap(mini))
     .pipe(uglify())
     .pipe(wrap(signatrue))
-    .pipe(gulp.dest('./dist'))
+    .pipe(gulp.dest('./dist/'))
     .on("error", function(err){
       throw err
     })
@@ -180,7 +185,8 @@ gulp.task('v', function(fn){
 
 
 gulp.task('watch', ["build", 'testbundle'], function(){
-  gulp.watch(['test/spec/*.js', 'lib/**/*.js'], ['jshint','testbundle'])
+  gulp.watch(['test/spec/*.js'], ['testbundle']);
+  gulp.watch(['lib/**/*.js'], ['build']);
 })
 
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -142,7 +142,7 @@ gulp.task('build',["jshint"], function(){
         }),
         commonjs(),
         replace({
-          'process.env.NODE_ENV': isProduction ? "production":"developement"
+          'process.env.NODE_ENV': JSON.stringify(isProduction ? "production":"developement")
         })
      ]
     })

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -137,7 +137,6 @@ gulp.task('build',["jshint"], function(){
       name: 'Regular',
       plugins: [
         nodeResolve({
-          jsnext: true,
           main: true
         }),
         commonjs(),

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -142,7 +142,7 @@ gulp.task('build',["jshint"], function(){
         }),
         commonjs(),
         replace({
-          'process.env.NODE_ENV': JSON.stringify(isProduction ? "production":"developement")
+          'process.env.NODE_ENV': JSON.stringify(isProduction ? "production":"development")
         })
      ]
     })

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
   },
   "homepage": "http://regularjs.github.io",
   "scripts": {
+    "watch": "gulp watch",
     "test": "gulp travis --chromeHeadless",
-    "prepublish": "gulp build"
+    "prepublish": "gulp build --production"
   },
   "bin": {
     "regular": "./bin/regular"
@@ -48,6 +49,7 @@
     "puppeteer": "^0.12.0",
     "rollup-plugin-commonjs": "^8.2.6",
     "rollup-plugin-node-resolve": "^3.0.0",
+    "rollup-plugin-replace": "^2.0.0",
     "rollup-stream": "^1.24.1",
     "run-sequence": "^1.2.2",
     "through2": "~0.4.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "http://regularjs.github.io",
   "scripts": {
-    "test": "gulp travis --phantomjs",
+    "test": "gulp travis --chromeHeadless",
     "prepublish": "gulp build"
   },
   "bin": {
@@ -28,6 +28,7 @@
   "devDependencies": {
     "expect.js": "~0.3.1",
     "gulp": "3.6.x",
+    "gulp-better-rollup": "^2.0.0",
     "gulp-bump": "^1.0.0",
     "gulp-git": "^1.4.0",
     "gulp-istanbul": "~0.1.1",
@@ -37,17 +38,22 @@
     "gulp-tag-version": "^1.3.0",
     "gulp-uglify": "~0.2.1",
     "gulp-util": "~2.2.14",
-    "gulp-webpack": "^1.0.0",
-    "karma": "^1.3.0",
-    "karma-chrome-launcher": "~0.1.4",
+    "karma": "^1.7.1",
+    "karma-chrome-launcher": "^2.2.0",
     "karma-coverage": "~0.2.4",
     "karma-firefox-launcher": "~0.1.3",
     "karma-ie-launcher": "~0.1.5",
     "karma-mocha": "~0.1.3",
-    "karma-phantomjs-launcher": "~0.1.4",
     "mocha": "~1.18.2",
+    "puppeteer": "^0.12.0",
+    "rollup-plugin-commonjs": "^8.2.6",
+    "rollup-plugin-node-resolve": "^3.0.0",
+    "rollup-stream": "^1.24.1",
     "run-sequence": "^1.2.2",
     "through2": "~0.4.1",
+    "vinyl-buffer": "^1.0.0",
+    "vinyl-source-stream": "^1.1.0",
+    "webpack-stream": "^4.0.0",
     "yargs": "^3.26.0"
   }
 }


### PR DESCRIPTION
+ Update gulpfile and travisci config file to use headless chrome for e2e test.
+ Use rollup for bundling, which reduced minified bundle size to 66kb(5kb smaller).
+ Inject` process.env.NODE_ENV ` when bundling, which allows writing code dedicated for development(concise warnning for developer,  internal performance test , etc). Those code will be removed in the production build.
+ Remove redundant code in gulpfile.