### PR TITLE
fix error position track

### DIFF
--- a/lib/parser/Lexer.js
+++ b/lib/parser/Lexer.js
@@ -28,7 +28,7 @@ function Lexer(input, opts){
     this.markEnd = config.END;
   }
 
-  this.input = (input||"").trim();
+  this.input = input||"";
   this.opts = opts || {};
   this.map = this.opts.mode !== 2?  map1: map2;
   this.states = ["INIT"];
@@ -42,12 +42,14 @@ var lo = Lexer.prototype
 
 
 lo.lex = function(str){
-  str = (str || this.input).trim();
+  str = str || this.input
+  var leadingWhitespaces = /^\s*/.exec(str)
+  str = str.trim();
   var tokens = [], split, test,mlen, token, state;
   this.input = str, 
   this.marks = 0;
-  // init the pos index
-  this.index=0;
+  // fix the pos offset caused by trim
+  this.index=leadingWhitespaces ? leadingWhitespaces[0].length : 0;
   var i = 0;
   while(str){
     i++

--- a/lib/util.js
+++ b/lib/util.js
@@ -125,32 +125,45 @@ _.makePredicate = function makePredicate(words, prefix) {
 _.trackErrorPos = (function (){
   // linebreak
   var lb = /\r\n|[\n\r\u2028\u2029]/g;
-  var minRange = 20, maxRange = 20;
+  var minRange = 50, maxRange = 20;
   function findLine(lines, pos){
     var tmpLen = 0;
     for(var i = 0,len = lines.length; i < len; i++){
       var lineLen = (lines[i] || "").length;
 
       if(tmpLen + lineLen > pos) {
-        return {num: i, line: lines[i], start: pos - i - tmpLen , prev:lines[i-1], next: lines[i+1] };
+        return {num: i, line: lines[i], start: pos - tmpLen , prev:lines[i-1], next: lines[i+1] };
       }
       // 1 is for the linebreak
-      tmpLen = tmpLen + lineLen ;
+      tmpLen = tmpLen + lineLen + 1;
     }
   }
-  function formatLine(str,  start, num, target){
+  function formatLine(str, column, row, target){
     var len = str.length;
-    var min = start - minRange;
+    var min = column - minRange;
     if(min < 0) min = 0;
-    var max = start + maxRange;
+    var max = column + maxRange;
     if(max > len) max = len;
 
     var remain = str.slice(min, max);
-    var prefix = "[" +(num+1) + "] " + (min > 0? ".." : "")
+    var prefix = "[" +(row+1) + "] " + (min > 0? ".." : "")
     var postfix = max < len ? "..": "";
-    var res = prefix + remain + postfix;
-    if(target) res += "\n" + new Array(start-min + prefix.length + 1).join(" ") + "^^^";
+    var res = prefix + leadingTabsToSpaces(remain) + postfix;
+    if(target) {
+      res += "\n" + spaces(
+        leadingTabsToSpaces(str.slice(min,column)).length +
+        prefix.length
+      ) + "^";
+    }
     return res;
+  }
+  function spaces(n) {
+    return new Array(n+1).join(" ")
+  }
+  function leadingTabsToSpaces(str) {
+    return str.replace( /^\t+/, function(match) {
+      return match.split('\t').join('  ');
+    } )
   }
   return function(input, pos){
     if(pos > input.length-1) pos = input.length-1;

--- a/test/spec/test-util.js
+++ b/test/spec/test-util.js
@@ -239,8 +239,8 @@ describe("Regular.util", function(){
 
 
   it("_.trackErrorPos should have no '...' prefix if not slice", function(){
-    expect(_.trackErrorPos("abcdefghi", 1)).to.equal('[1] abcdefghi\n     ^^^\n');
-    expect(_.trackErrorPos("abcdefghi", 2)).to.equal('[1] abcdefghi\n      ^^^\n');
+    expect(_.trackErrorPos("abcdefghi", 1)).to.equal('[1] abcdefghi\n     ^\n');
+    expect(_.trackErrorPos("abcdefghi", 2)).to.equal('[1] abcdefghi\n      ^\n');
 
 
   })


### PR DESCRIPTION
之前的错误定位存在一些问题，导致无法在模板中准确地定位到错误位置

主要修复了以下问题：
- lexer 中对 str 进行了trim，但没有对 index 进行修正
- trackErrorPos 方法没有对 tabs 进行处理
- trackErrorPos 中的 findLine 每一次遍历都需要执行 `tmpLen + lineLen > pos`，但 `tmpLen` 没有"及时"加上 linebreak 的1

之前：

<img src="https://user-images.githubusercontent.com/9125255/34035348-bd49dee2-e1bc-11e7-94f5-aefbee578e92.jpg" width="400" />
<img src="https://user-images.githubusercontent.com/9125255/34035380-d4a660e2-e1bc-11e7-8ec0-8f6eb4379002.jpg" width="400" />

现在：

<img src="https://user-images.githubusercontent.com/9125255/34035356-c67b13dc-e1bc-11e7-8950-016c59703d11.jpg" width="400" />
<img src="https://user-images.githubusercontent.com/9125255/34035384-d9e74fd0-e1bc-11e7-81cb-d4bd7caa4b49.jpg" width="400" />

把 `^^^` 改成了 `^`，感觉应该不会有问题...

